### PR TITLE
Add test config, specify different hasher_module

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+if has guix; then
+    use guix erlang elixir elixir-hex just
+fi

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
 import Config
 
-config :bonfire_data_identity, Bonfire.Data.Identity.Credential, hasher_module: Pbkdf2
+import_config "#{Mix.env()}.exs"

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,3 @@
+import Config
+
+config :bonfire_data_identity, Bonfire.Data.Identity.Credential, hasher_module: Pbkdf2

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,3 @@
+import Config
+
+config :bonfire_data_identity, Bonfire.Data.Identity.Credential, hasher_module: Argon2


### PR DESCRIPTION
This is required by bonfire at
https://github.com/bonfire-networks/bonfire/blob/main/config/test.exs#L61
and was discovered by building bonfire_common.